### PR TITLE
[UPDATE] 상품 주문 기능 개선

### DIFF
--- a/jpashop/src/main/java/jpabook/jpashop/InitDb.java
+++ b/jpashop/src/main/java/jpabook/jpashop/InitDb.java
@@ -19,9 +19,9 @@ public class InitDb {
 
     @PostConstruct
     public void init(){
-        initService.dbInit1();
+        initService.createAdmin();
         initService.dbInit2();
-        initService.dbInit3();
+        initService.createMember();
         initService.dbInit4();
     }
 
@@ -31,22 +31,10 @@ public class InitDb {
     static class InitService {
 
         private final EntityManager em;
-        public void dbInit1(){
-            Address address1 = Address.createAddress("수원", "행궁동", "23541");
-            Member member1 = Member.createMember("ID1","PASSWORD1","userA", address1);
+        public void createAdmin(){
+            Address address1 = Address.createAddress("화성시", "동탄 순환대로 10길", "23541");
+            Member member1 = Member.createMember("ADMIN","PASSWORD","운영자", address1);
             em.persist(member1);
-            Book book1 = Book.createBook("JPA1 BOOK", 38700, 100, "김영한", "12321");
-            em.persist(book1);
-            Book book2 = Book.createBook("JPA2 BOOK", 28700, 200, "김영한", "23451");
-            em.persist(book2);
-
-            /** order 만 persist 하는 이유! **/
-            /** cascade 로 엮어져 있기 때문! **/
-            OrderItem orderItem1 = OrderItem.createOrderItem(book1, book1.getPrice(), 1);
-            OrderItem orderItem2 = OrderItem.createOrderItem(book2, book2.getPrice(), 2);
-            Delivery delivery1 = Delivery.createDelivery(address1);
-            Order order = Order.createOrder(member1, delivery1, orderItem1, orderItem2);
-            em.persist(order);
         }
 
         public void dbInit2(){
@@ -67,7 +55,8 @@ public class InitDb {
             em.persist(order);
         }
 
-        public void dbInit3(){
+        public void createMember(){
+            String password = "password";
             Member member1 = Member.createMember("email1@gmail.com", "password", "userA", Address.createAddress("cityA", "streetA", "111111"));
             em.persist(member1);
             Member member2 = Member.createMember("email2@gmail.com", "password", "userB", Address.createAddress("cityB", "streetB", "111111"));

--- a/jpashop/src/main/java/jpabook/jpashop/controller/OrderController.java
+++ b/jpashop/src/main/java/jpabook/jpashop/controller/OrderController.java
@@ -35,11 +35,11 @@ public class OrderController {
     }
 
     @PostMapping("/order")
-    public String order(@RequestParam("memberId") Long memberId,
+    public String order(@SessionAttribute(name = SessionConst.LOGIN_MEMBER, required = false)Member member,
                         @RequestParam("itemId") Long itemId,
                         @RequestParam("count") int count){
 
-        orderService.order(memberId, itemId, count);
+        orderService.order(member.getId(), itemId, count);
         return "redirect:/orders";
     }
 

--- a/jpashop/src/main/java/jpabook/jpashop/controller/item/ItemController.java
+++ b/jpashop/src/main/java/jpabook/jpashop/controller/item/ItemController.java
@@ -1,14 +1,14 @@
 package jpabook.jpashop.controller.item;
 
 import jpabook.jpashop.controller.item.BookForm;
-import jpabook.jpashop.domain.item.Album;
-import jpabook.jpashop.domain.item.Book;
-import jpabook.jpashop.domain.item.Item;
-import jpabook.jpashop.domain.item.Movie;
+import jpabook.jpashop.domain.item.*;
 import jpabook.jpashop.exception.NotCorrespondingItemException;
 import jpabook.jpashop.service.ItemService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -55,8 +55,8 @@ public class ItemController {
     }
 
     @GetMapping("/items")
-    public String list(Model model){
-        model.addAttribute("items",itemService.findItems());
+    public String items(@PageableDefault(size = 8) Pageable pageable, Model model){
+        model.addAttribute("items",itemService.findAll(pageable));
         return "items/itemList";
     }
 
@@ -71,9 +71,7 @@ public class ItemController {
 
     @PostMapping("items/{itemId}/edit")
     public String updateItem(@PathVariable Long itemId, @ModelAttribute("form") BookForm form) {
-
         itemService.updateItem(itemId, form.getName(), form.getPrice(), form.getStockQuantity());
-
         return "redirect:/items";
     }
 }

--- a/jpashop/src/main/java/jpabook/jpashop/domain/item/ItemDto.java
+++ b/jpashop/src/main/java/jpabook/jpashop/domain/item/ItemDto.java
@@ -1,0 +1,18 @@
+package jpabook.jpashop.domain.item;
+
+import lombok.Data;
+
+@Data
+public class ItemDto {
+    private Long id;
+    private String name;
+    private int price;
+    private int stockQuantity;
+
+    public ItemDto(Item item) {
+        this.id = item.getId();
+        this.name = item.getName();
+        this.price = item.getPrice();
+        this.stockQuantity = item.getStockQuantity();
+    }
+}

--- a/jpashop/src/main/java/jpabook/jpashop/repository/ItemRepository.java
+++ b/jpashop/src/main/java/jpabook/jpashop/repository/ItemRepository.java
@@ -1,6 +1,7 @@
 package jpabook.jpashop.repository;
 
 import jpabook.jpashop.domain.item.Item;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,7 +9,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface ItemRepository extends JpaRepository<Item, Long> {
-
-    Optional<Item> findById(Long id);
 
 }

--- a/jpashop/src/main/java/jpabook/jpashop/service/ItemService.java
+++ b/jpashop/src/main/java/jpabook/jpashop/service/ItemService.java
@@ -1,9 +1,11 @@
 package jpabook.jpashop.service;
 
 import jpabook.jpashop.domain.item.Item;
+import jpabook.jpashop.domain.item.ItemDto;
 import jpabook.jpashop.exception.NotCorrespondingItemException;
 import jpabook.jpashop.repository.ItemRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -37,5 +39,9 @@ public class ItemService {
         Optional<Item> findItem = itemRepository.findById(itemId);
         Item item = findItem.orElseThrow(() -> new NotCorrespondingItemException("해당하는 아이템이 존재하지 않습니다."));
         item.updateItem(name,price,stockQuantity);
+    }
+
+    public Page<ItemDto> findAll(Pageable pageable){
+        return itemRepository.findAll(pageable).map(p -> new ItemDto(p));
     }
 }

--- a/jpashop/src/main/resources/templates/home.html
+++ b/jpashop/src/main/resources/templates/home.html
@@ -11,26 +11,26 @@
         <h1>HOME</h1>
         <div style="text-align:right">
             <form action="/logout" method="post">
-                <button type="submit" class="btn btn-outline-warning btn-sm">로그아웃</button>
+                <button type="submit" class="btn btn-outline-danger btn-sm">로그아웃</button>
             </form>
         </div>
         <hr/>
         <div class="row">
             <div class="col-sm-6">
-                <div class="card">
+                <div class="card" style="height:100%">
                     <div class="card-body">
                         <h5 class="card-title">회원 가입</h5>
-                        <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
-                        <a href="/members/new" class="btn btn-primary">Go somewhere</a>
+                        <p class="card-text">회원을 등록하여 JPA SHOP의 서비스를 이용하세요.</p>
+                        <a href="/members/new" class="btn btn-secondary">회원 가입 바로가기</a>
                     </div>
                 </div>
             </div>
             <div class="col-sm-6">
-                <div class="card">
+                <div class="card" style="height:100%">
                     <div class="card-body">
                         <h5 class="card-title">회원 목록</h5>
-                        <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
-                        <a href="/members" class="btn btn-primary">Go somewhere</a>
+                        <p class="card-text">현재 JPA SHOP 서비스에 등록된 모든 회원 목록을 제공합니다.</p>
+                        <a href="/members" class="btn btn-secondary">회원 목록 바로가기</a>
                     </div>
                 </div>
             </div>
@@ -38,20 +38,20 @@
         <br/>
         <div class="row">
             <div class="col-sm-6">
-                <div class="card">
+                <div class="card" style="height:100%">
                     <div class="card-body">
                         <h5 class="card-title">상품 등록</h5>
-                        <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
-                        <a href="/items/new" class="btn btn-primary">Go somewhere</a>
+                        <p class="card-text">JPA SHOP 서비스에 판매할 상품을 등록합니다.</p>
+                        <a href="/items/new" class="btn btn-secondary">상품 등록 바로가기</a>
                     </div>
                 </div>
             </div>
             <div class="col-sm-6">
-                <div class="card">
+                <div class="card" style="height:100%">
                     <div class="card-body">
                         <h5 class="card-title">상품 목록</h5>
-                        <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
-                        <a href="/items" class="btn btn-primary">Go somewhere</a>
+                        <p class="card-text">현재 JPA SHOP 서비스에 등록된 모든 상품 목록을 제공합니다.</p>
+                        <a href="/items" class="btn btn-secondary">상품 목록 바로가기</a>
                     </div>
                 </div>
             </div>
@@ -59,20 +59,20 @@
         <br/>
         <div class="row">
             <div class="col-sm-6">
-                <div class="card">
+                <div class="card" style="height:100%">
                     <div class="card-body">
                         <h5 class="card-title">상품 주문</h5>
-                        <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
-                        <a href="/order" class="btn btn-primary">Go somewhere</a>
+                        <p class="card-text">현재 JPA SHOP 서비스에 등록된 상품을 주문합니다.</p>
+                        <a href="/order" class="btn btn-secondary">상품 주문 바로가기</a>
                     </div>
                 </div>
             </div>
             <div class="col-sm-6">
-                <div class="card">
+                <div class="card" style="height:100%">
                     <div class="card-body">
                         <h5 class="card-title">주문 목록</h5>
-                        <p class="card-text">With supporting text below as a natural lead-in to additional content.</p>
-                        <a href="/orders" class="btn btn-primary">Go somewhere</a>
+                        <p class="card-text">현재 JPA SHOP 서비스에서 주문된 모든 주문 목록을 제공합니다.</p>
+                        <a href="/orders" class="btn btn-secondary">주문 목록 바로가기</a>
                     </div>
                 </div>
             </div>

--- a/jpashop/src/main/resources/templates/items/itemList.html
+++ b/jpashop/src/main/resources/templates/items/itemList.html
@@ -6,14 +6,15 @@
     <div th:replace="fragments/bodyHeader :: bodyHeader"/>
     <H1>ITEM LIST</H1>
     <br/>
+
     <div>
-        <table class="table table-striped">
+        <table class="table">
             <thead>
-            <tr>
-                <th>#</th>
-                <th>상품명</th>
-                <th>가격</th>
-                <th>재고수량</th>
+            <tr class="table-secondary">
+                <th class="col-1">#</th>
+                <th class="col-3">상품명</th>
+                <th class="col-3">가격</th>
+                <th class="col-3">재고수량</th>
                 <th></th>
             </tr>
             </thead>
@@ -25,11 +26,16 @@
                 <td th:text="${item.stockQuantity}"></td>
                 <td>
                     <a href="#" th:href="@{/items/{id}/edit (id=${item.id})}"
-                       class="btn btn-primary" role="button">수정</a>
+                       class="btn btn-outline-danger btn-sm" role="button">수정</a>
                 </td>
             </tr>
             </tbody>
         </table>
+    </div>
+    <div class="btn-group me-2" role="group" aria-label="First group">
+        <th:block th:each = "i : ${#numbers.sequence(1,items.totalPages)}">
+            <a type="button" class="btn btn-outline-secondary" th:text="${i}" th:href="@{items(page=${i-1})}"></a>
+        </th:block>
     </div>
     <div th:replace="fragments/footer :: footer"/>
 </div> <!-- /container -->

--- a/jpashop/src/main/resources/templates/members/memberList.html
+++ b/jpashop/src/main/resources/templates/members/memberList.html
@@ -6,7 +6,7 @@
   <div th:replace="fragments/bodyHeader :: bodyHeader" />
   <H1>MEMBER LIST</H1>
   <br/>
-  <div style="text-align: center" >
+
     <table class="table">
       <thead>
       <tr class="table-secondary">
@@ -31,7 +31,6 @@
         <a type="button" class="btn btn-outline-secondary" th:text="${i}" th:href="@{members(page=${i-1})}"></a>
       </th:block>
     </div>
-  </div>
   <div th:replace="fragments/footer :: footer" />
 </div> <!-- /container -->
 </body>

--- a/jpashop/src/main/resources/templates/order/orderForm.html
+++ b/jpashop/src/main/resources/templates/order/orderForm.html
@@ -2,32 +2,30 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <head th:replace="fragments/header :: header" />
 <body>
-<div class="container">
+<div class="container col-5" style="text-align:center">
     <div th:replace="fragments/bodyHeader :: bodyHeader"/>
+    <h1>상품 주문</h1>
+    <br/>
     <form role="form" action="/order" method="post">
-        <div class="form-group">
-            <label for="member">주문회원</label>
-            <select name="memberId" id="member" class="form-control">
-                <option value="">회원선택</option>
-                <option th:each="member : ${members}"
-                        th:value="${member.id}"
-                        th:text="${member.username}" />
-            </select>
-        </div>
-        <div class="form-group">
-            <label for="item">상품명</label>
+
+        <div class="form-floating mb-3">
             <select name="itemId" id="item" class="form-control">
-                <option value="">상품선택</option>
+                <option value=""></option>
                 <option th:each="item : ${items}"
                         th:value="${item.id}"
                         th:text="${item.name}" />
             </select>
+            <label for="item">상품명</label>
         </div>
-        <div class="form-group">
-            <label for="count">주문수량</label>
+
+        <div class="form-floating mb-3">
             <input type="number" name="count" class="form-control" id="count" placeholder="주문 수량을 입력하세요">
+            <label for="count">주문 수량</label>
         </div>
-        <button type="submit" class="btn btn-primary">Submit</button>
+
+        <div class="d-grid gap-2">
+            <button type="submit" class="btn btn-outline-secondary">주문하기</button>
+        </div>
     </form>
     <br/>
     <div th:replace="fragments/footer :: footer" />

--- a/jpashop/src/main/resources/templates/order/orderList.html
+++ b/jpashop/src/main/resources/templates/order/orderList.html
@@ -30,14 +30,14 @@
         </div>
         <hr/>
 
-        <table class="table table-striped">
+        <table class="table">
             <thead>
-            <tr>
+            <tr class="table-secondary">
                 <th>#</th>
                 <th>회원명</th>
                 <th>상품 이름</th>
-                <th>상품 주문가격</th>
-                <th>상품 주문수량</th>
+                <th>주문가격</th>
+                <th>주문수량</th>
                 <th>상태</th>
                 <th>일시</th>
                 <th></th>
@@ -57,7 +57,7 @@
                     <td>
                         <a th:if="${order.status.name() == 'ORDER'}" href="#"
                            th:href="'javascript:cancel('+${order.id}+')'"
-                           class="btn btn-danger">CANCEL</a>
+                           class="btn btn-outline-danger btn-sm">CC</a>
                     </td>
                 </tr>
             </th:block>


### PR DESCRIPTION
- 기존의 상품 주문 페이지는 사용자가 `주문 회원`, `상품명`, `주문 수량` 총 3개의 정보를 서버에 제공했다.
- 이전에는 **로그인** 기능이 없어서 현재 페이지를 사용하고 있는 회원의 정보를 알 수 없었다.
- 현재는 로그인 기능의 **세션**을 통해 현재 페이지를 사용하고 있는 회원의 정보를 알 수 있다.
- 기존의 `주문 회원`의 정보를 전달하는 `<input>`을 삭제하고 세션을 통해 상품 주문을 진행할 수 있도록 기능을 개선하였다.